### PR TITLE
Updates semver dependency to `^5.4.1`

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "coveralls": "npm run cover && istanbul-coveralls"
   },
   "dependencies": {
-    "semver": "^4.2.0",
+    "semver": "^5.4.1",
     "semver-regex": "^1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
`npm test` runs as expected:

```
$ npm test

> semver-greatest-satisfied-range@1.0.0 pretest /git-repos/semver-greatest-satisfied-range
> npm run lint


> semver-greatest-satisfied-range@1.0.0 lint /git-repos/semver-greatest-satisfied-range
> eslint . && jscs index.js test/


> semver-greatest-satisfied-range@1.0.0 test /git-repos/semver-greatest-satisfied-range
> mocha --async-only



  findRange
    ✓ works with different ranges
    ✓ works with multiple matching ranges
    ✓ returns null with no matching ranges
    ✓ prerelease ranges
    ✓ prerelease ranges against release version
    ✓ prerelease and release ranges
    ✓ prerelease and release ranges against prerelease version


  7 passing (22ms)
```
